### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/map_prepare/lib/anvil/block.py
+++ b/map_prepare/lib/anvil/block.py
@@ -96,8 +96,8 @@ class Block:
         data
             Numeric data, used to represent variants of the block
         """
-        # See https://minecraft.gamepedia.com/Java_Edition_data_value/Pre-flattening
-        # and https://minecraft.gamepedia.com/Java_Edition_data_value for current values
+        # See https://minecraft.wiki/w/Java_Edition_data_value/Pre-flattening
+        # and https://minecraft.wiki/w/Java_Edition_data_value for current values
         key = f'{block_id}:{data}'
         if key not in LEGACY_ID_MAP:
             raise KeyError(f'Block {key} not found')

--- a/map_prepare/lib/anvil/chunk.py
+++ b/map_prepare/lib/anvil/chunk.py
@@ -160,7 +160,7 @@ class Chunk:
             y %= 16
 
         if self.version is None or self.version < _VERSION_17w47a:
-            # Explained in depth here https://minecraft.wiki/w/WChunk_format?oldid=1153403#Block_format
+            # Explained in depth here https://minecraft.wiki/w/Chunk_format?oldid=1153403#Block_format
 
             if section is None or 'Blocks' not in section:
                 if force_new:

--- a/map_prepare/lib/anvil/chunk.py
+++ b/map_prepare/lib/anvil/chunk.py
@@ -10,7 +10,7 @@ import math
 # so a block value isn't in multiple elements of the array
 _VERSION_20w17a = 2529
 
-# This is the version where "The Flattening" (https://minecraft.gamepedia.com/Java_Edition_1.13/Flattening) happened
+# This is the version where "The Flattening" (https://minecraft.wiki/w/Java_Edition_1.13/Flattening) happened
 # where blocks went from numeric ids to namespaced ids (namespace:block_id)
 _VERSION_17w47a = 1451
 
@@ -61,7 +61,7 @@ class Chunk:
             self.version = nbt_data['DataVersion'].value
         except KeyError:
             # Version is pre-1.9 snapshot 15w32a, so world does not have a Data Version.
-            # See https://minecraft.fandom.com/wiki/Data_version
+            # See https://minecraft.wiki/w/Data_version
             self.version = None
 
         if self.version < _VERSION_21w43a:
@@ -160,7 +160,7 @@ class Chunk:
             y %= 16
 
         if self.version is None or self.version < _VERSION_17w47a:
-            # Explained in depth here https://minecraft.gamepedia.com/index.php?title=Chunk_format&oldid=1153403#Block_format
+            # Explained in depth here https://minecraft.wiki/w/WChunk_format?oldid=1153403#Block_format
 
             if section is None or 'Blocks' not in section:
                 if force_new:


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki

There were also some older gamepedia URLs that I also updated.